### PR TITLE
feat(fujifilm): dispatch MakerNotes so the generated tables are reachable

### DIFF
--- a/src/exif/ifd.rs
+++ b/src/exif/ifd.rs
@@ -398,11 +398,16 @@ impl ExifReader {
                         value_extraction::extract_long_value(data, entry, byte_order)? as i32,
                     )
                 } else {
-                    // No signed array helper either; the reinterpretation is
-                    // per element. FujiFilm 0x100A (FocusPixel) is SLONG count 2.
-                    TagValue::U32Array(value_extraction::extract_long_array(
-                        data, entry, byte_order,
-                    )?)
+                    // No signed array helper and no I32Array variant, so the
+                    // reinterpretation is per element into a heterogeneous
+                    // Array. Storing these as U32Array would print
+                    // WhiteBalanceFineTune's -100 as 4294967196.
+                    TagValue::Array(
+                        value_extraction::extract_long_array(data, entry, byte_order)?
+                            .into_iter()
+                            .map(|v| TagValue::I32(v as i32))
+                            .collect(),
+                    )
                 }
             }
             TiffFormat::SShort => {
@@ -411,9 +416,12 @@ impl ExifReader {
                         value_extraction::extract_short_value(data, entry, byte_order)? as i16,
                     )
                 } else {
-                    TagValue::U16Array(value_extraction::extract_short_array_value(
-                        data, entry, byte_order,
-                    )?)
+                    TagValue::Array(
+                        value_extraction::extract_short_array_value(data, entry, byte_order)?
+                            .into_iter()
+                            .map(|v| TagValue::I16(v as i16))
+                            .collect(),
+                    )
                 }
             }
             TiffFormat::Rational => {

--- a/src/exif/ifd.rs
+++ b/src/exif/ifd.rs
@@ -219,6 +219,13 @@ impl ExifReader {
                 "Calling Sony subdirectory processing for Tag2010, Tag9050, AFInfo and other binary sections"
             );
             crate::implementations::sony::process_sony_subdirectory_tags(self)?;
+        } else if maker_notes_data.starts_with(b"FUJIFILM")
+            || maker_notes_data.starts_with(b"GENERALE")
+        {
+            debug!("Detected FujiFilm MakerNotes signature, dispatching on data");
+            // Register before descending, as the Canon branch above does.
+            self.processed.insert(addr, "MakerNotes".to_string());
+            self.process_fujifilm_makernotes(&maker_notes_data)?;
         } else {
             // Fall back to generic tag kit processing for other manufacturers
             debug!("Non-Canon/Olympus camera, using generic MakerNotes processing");
@@ -237,6 +244,193 @@ impl ExifReader {
 
         Ok(())
     }
+
+    /// Process FujiFilm MakerNotes.
+    ///
+    /// ExifTool: lib/Image/ExifTool/MakerNotes.pm:121-134 (MakerNoteFujiFilm)
+    ///   Condition => '$$valPt =~ /^(FUJIFILM|GENERALE)/'
+    ///   OffsetPt  => '$valuePtr+8'   4-byte LE pointer to the IFD
+    ///   Base      => '$start'        value pointers are subdirectory-relative
+    ///   ByteOrder => 'LittleEndian'  regardless of the file's byte order
+    ///
+    /// Dispatch is on the DATA signature and never on Make, because the same
+    /// header is written by some Leica, Minolta and Sharp bodies
+    /// (MakerNotes.pm:122) and by GE models writing "GENERALE".
+    ///
+    /// Two details here are easy to get wrong, and both fail silently.
+    ///
+    /// The IFD does not begin 8 bytes in. Byte 8 holds a pointer TO the IFD,
+    /// which is 12 on every X-series file measured and is not a constant.
+    ///
+    /// `Base => '$start'` makes value pointers relative to the MakerNotes start
+    /// rather than to the TIFF header, which is why this parses from the
+    /// subdirectory slice instead of calling parse_ifd: value_extraction
+    /// resolves value_or_offset against whatever slice it is given, so passing
+    /// the subdirectory makes the base right by construction. Reading them
+    /// TIFF-relative still parses, since inline values are unaffected, and only
+    /// the out-of-line ones come back wrong (Quality reads as an empty string
+    /// while FilmMode reads correctly).
+    fn process_fujifilm_makernotes(&mut self, data: &[u8]) -> Result<()> {
+        // ExifTool: ByteOrder => 'LittleEndian'
+        let byte_order = ByteOrder::LittleEndian;
+
+        if data.len() < 12 {
+            self.warnings.push(format!(
+                "FujiFilm MakerNotes too small for header: {} bytes",
+                data.len()
+            ));
+            return Ok(());
+        }
+
+        // ExifTool: OffsetPt => '$valuePtr+8'
+        let ifd_offset = u32::from_le_bytes([data[8], data[9], data[10], data[11]]) as usize;
+
+        if ifd_offset + 2 > data.len() {
+            self.warnings.push(format!(
+                "FujiFilm IFD pointer {:#x} is beyond {} bytes of MakerNotes",
+                ifd_offset,
+                data.len()
+            ));
+            return Ok(());
+        }
+
+        let num_entries = byte_order.read_u16(data, ifd_offset)? as usize;
+
+        // Bound the directory before reading it. entry.count is attacker
+        // controlled elsewhere and so is this: a malformed file can claim more
+        // entries than the subdirectory holds.
+        if ifd_offset + 2 + num_entries * 12 > data.len() {
+            self.warnings.push(format!(
+                "FujiFilm IFD claims {} entries, only {} bytes available",
+                num_entries,
+                data.len() - ifd_offset
+            ));
+            return Ok(());
+        }
+
+        debug!(
+            "FujiFilm MakerNotes: IFD at {:#x} with {} entries",
+            ifd_offset, num_entries
+        );
+
+        let source_info = self.create_tag_source_info("FujiFilm");
+
+        for i in 0..num_entries {
+            let entry_offset = ifd_offset + 2 + i * 12;
+            let entry = match IfdEntry::parse(data, entry_offset, byte_order) {
+                Ok(entry) => entry,
+                Err(e) => {
+                    debug!("FujiFilm IFD entry {} unreadable: {}", i, e);
+                    continue;
+                }
+            };
+
+            match Self::extract_fujifilm_value(data, &entry, byte_order) {
+                Ok(value) => {
+                    trace!("FujiFilm tag {:#06x} = {:?}", entry.tag_id, value);
+                    self.store_tag_with_precedence(entry.tag_id, value, source_info.clone());
+                }
+                Err(e) => {
+                    debug!("FujiFilm tag {:#06x} skipped: {}", entry.tag_id, e);
+                }
+            }
+        }
+
+        Ok(())
+    }
+
+    /// Read one FujiFilm IFD entry's value out of the MakerNotes slice.
+    ///
+    /// Raw values only. Conversions run in get_all_tag_entries (see the module
+    /// note at the top of this file), so nothing here applies a PrintConv.
+    fn extract_fujifilm_value(
+        data: &[u8],
+        entry: &IfdEntry,
+        byte_order: ByteOrder,
+    ) -> Result<TagValue> {
+        let single = entry.count == 1;
+
+        Ok(match entry.format {
+            TiffFormat::Ascii => TagValue::String(value_extraction::extract_ascii_value(
+                data,
+                entry,
+                byte_order,
+                entry.tag_id,
+            )?),
+            TiffFormat::Byte | TiffFormat::Undefined | TiffFormat::SByte => {
+                if single && entry.format == TiffFormat::Byte {
+                    TagValue::U8(value_extraction::extract_byte_value(data, entry)?)
+                } else {
+                    TagValue::U8Array(value_extraction::extract_byte_array_value(
+                        data, entry, byte_order,
+                    )?)
+                }
+            }
+            TiffFormat::Short => {
+                if single {
+                    TagValue::U16(value_extraction::extract_short_value(
+                        data, entry, byte_order,
+                    )?)
+                } else {
+                    TagValue::U16Array(value_extraction::extract_short_array_value(
+                        data, entry, byte_order,
+                    )?)
+                }
+            }
+            TiffFormat::Long => {
+                if single {
+                    TagValue::U32(value_extraction::extract_long_value(
+                        data, entry, byte_order,
+                    )?)
+                } else {
+                    TagValue::U32Array(value_extraction::extract_long_array(
+                        data, entry, byte_order,
+                    )?)
+                }
+            }
+            // No signed helpers exist in value_extraction; the widths are
+            // identical, so read unsigned and reinterpret. FujiFilm's tone,
+            // grain and colour-chrome tags are all SLONG, so this arm carries
+            // most of the film recipe.
+            TiffFormat::SLong => {
+                if single {
+                    TagValue::I32(
+                        value_extraction::extract_long_value(data, entry, byte_order)? as i32,
+                    )
+                } else {
+                    // No signed array helper either; the reinterpretation is
+                    // per element. FujiFilm 0x100A (FocusPixel) is SLONG count 2.
+                    TagValue::U32Array(value_extraction::extract_long_array(
+                        data, entry, byte_order,
+                    )?)
+                }
+            }
+            TiffFormat::SShort => {
+                if single {
+                    TagValue::I16(
+                        value_extraction::extract_short_value(data, entry, byte_order)? as i16,
+                    )
+                } else {
+                    TagValue::U16Array(value_extraction::extract_short_array_value(
+                        data, entry, byte_order,
+                    )?)
+                }
+            }
+            TiffFormat::Rational => {
+                value_extraction::extract_rational_value(data, entry, byte_order)?
+            }
+            TiffFormat::SRational => {
+                value_extraction::extract_srational_value(data, entry, byte_order)?
+            }
+            other => {
+                return Err(ExifError::ParseError(format!(
+                    "unhandled FujiFilm format {:?} (count {})",
+                    other, entry.count
+                )))
+            }
+        })
+    }
+
     /// Process a subdirectory with recursion prevention
     /// ExifTool: ProcessDirectory with PROCESSED tracking
     pub(crate) fn process_subdirectory(&mut self, dir_info: &DirectoryInfo) -> Result<()> {

--- a/src/exif/mod.rs
+++ b/src/exif/mod.rs
@@ -277,7 +277,7 @@ impl ExifReader {
                 "Nikon" => format!("Nikon_0x{tag_id:04X}"),
                 "Olympus" => format!("Olympus_0x{tag_id:04X}"),
                 "Panasonic" => format!("Panasonic_0x{tag_id:04X}"),
-                "Fujifilm" => format!("Fujifilm_0x{tag_id:04X}"),
+                "FujiFilm" => format!("FujiFilm_0x{tag_id:04X}"),
                 _ => format!("Tag_{tag_id:04X}"),
             };
             tracing::debug!(
@@ -329,6 +329,20 @@ impl ExifReader {
                     return tag_def.name.to_string();
                 } else {
                     tracing::debug!("Canon tag 0x{:x} not found in CANON_MAIN_TAGS", tag_id);
+                }
+            }
+
+            // Check for FujiFilm MakerNotes tags
+            // ExifTool: FujiFilm.pm Main table, group1 "FujiFilm"
+            if source.namespace == "FujiFilm" {
+                use crate::generated::FujiFilm_pm::main_tags::FUJI_FILM_MAIN_TAGS;
+                if let Some(tag_def) = FUJI_FILM_MAIN_TAGS.get(&tag_id) {
+                    tracing::debug!(
+                        "Found FujiFilm tag name for 0x{:x}: {}",
+                        tag_id,
+                        tag_def.name
+                    );
+                    return tag_def.name.to_string();
                 }
             }
 
@@ -468,7 +482,7 @@ impl ExifReader {
                 let display_group = match namespace.as_str() {
                     "GPS" => "EXIF", // GPS tags have Group0="EXIF" per ExifTool GPS.pm:52
                     // Manufacturer MakerNotes tags display as "MakerNotes" group per ExifTool output
-                    "Canon" | "Nikon" | "Sony" | "Olympus" | "Panasonic" | "Fujifilm" => {
+                    "Canon" | "Nikon" | "Sony" | "Olympus" | "Panasonic" | "FujiFilm" => {
                         "MakerNotes"
                     }
                     other => other, // Keep other namespaces as-is
@@ -594,6 +608,7 @@ impl ExifReader {
                             name if name.starts_with("Canon") => false, // Canon maker notes - don't lookup GPS/EXIF tags
                             name if name.starts_with("Nikon") => false, // Nikon maker notes - don't lookup GPS/EXIF tags
                             name if name.starts_with("Olympus") => false, // Olympus maker notes - don't lookup GPS/EXIF tags
+                            name if name.starts_with("FujiFilm") => false, // FujiFilm maker notes - don't lookup GPS/EXIF tags
                             "MakerNotes" => false, // Generic maker notes - don't lookup GPS/EXIF tags
                             "KyoceraRaw" => false, // Kyocera RAW - don't lookup GPS/EXIF tags
                             "IFD0" if self.original_file_type.as_deref() == Some("RW2") => {
@@ -701,7 +716,20 @@ impl ExifReader {
                                 (panasonic_tag_name, None)
                             } else {
                                 // Check for manufacturer-specific maker note tags
-                                if source_info.ifd_name.starts_with("Canon")
+                                if source_info.ifd_name.starts_with("FujiFilm") {
+                                    // ExifTool: FujiFilm.pm Main table
+                                    use crate::generated::FujiFilm_pm::main_tags::FUJI_FILM_MAIN_TAGS;
+                                    let fujifilm_tag_name = FUJI_FILM_MAIN_TAGS
+                                        .get(&tag_id)
+                                        .map(|tag_def| tag_def.name.to_string())
+                                        .unwrap_or_else(|| {
+                                            Self::generate_tag_prefix_name(
+                                                tag_id,
+                                                Some(source_info),
+                                            )
+                                        });
+                                    (fujifilm_tag_name, None)
+                                } else if source_info.ifd_name.starts_with("Canon")
                                     || source_info.ifd_name == "MakerNotes"
                                 {
                                     // Use Canon-specific tag name lookup for Canon maker note tags
@@ -751,7 +779,7 @@ impl ExifReader {
                 _ => match raw_group_name {
                     "GPS" => "EXIF", // GPS tags have Group0="EXIF" per ExifTool GPS.pm:52
                     // Manufacturer MakerNotes tags display as "MakerNotes" group per ExifTool output
-                    "Canon" | "Nikon" | "Sony" | "Olympus" | "Panasonic" | "Fujifilm" => {
+                    "Canon" | "Nikon" | "Sony" | "Olympus" | "Panasonic" | "FujiFilm" => {
                         "MakerNotes"
                     }
                     other => other, // Keep other namespaces as-is

--- a/src/exif/tags.rs
+++ b/src/exif/tags.rs
@@ -177,7 +177,7 @@ impl ExifReader {
             name if name.starts_with("Sony") => "Sony",
             name if name.starts_with("Olympus") => "Olympus",
             name if name.starts_with("Panasonic") => "Panasonic",
-            name if name.starts_with("Fujifilm") => "Fujifilm",
+            name if name.starts_with("FujiFilm") => "FujiFilm",
             // RAW format-specific IFDs (maintain existing behavior)
             "KyoceraRaw" => "EXIF", // Kyocera RAW uses EXIF group
             _ => "EXIF",            // Default to EXIF for unknown IFDs
@@ -191,7 +191,7 @@ impl ExifReader {
             "Sony" => "Sony".to_string(),
             "Olympus" => "Olympus".to_string(),
             "Panasonic" => "Panasonic".to_string(),
-            "Fujifilm" => "Fujifilm".to_string(),
+            "FujiFilm" => "FujiFilm".to_string(),
             _ => "Exif".to_string(),
         };
 
@@ -211,6 +211,7 @@ impl ExifReader {
         source_info: Option<&TagSourceInfo>,
     ) -> (TagValue, TagValue) {
         use crate::generated::Exif_pm::main_tags;
+        use crate::generated::FujiFilm_pm::main_tags as fujifilm_tag_kit;
         use crate::generated::GPS_pm::main_tags as gps_tag_kit;
         use crate::generated::Sony_pm::main_tags as sony_tag_kit;
 
@@ -323,6 +324,42 @@ impl ExifReader {
                 (value, print)
             } else {
                 // No tag definition found, return raw value for both
+                (value.clone(), value)
+            }
+        } else if ifd_name == "FujiFilm"
+            || (source_info.is_some() && source_info.unwrap().namespace == "FujiFilm")
+        {
+            // FujiFilm MakerNotes: both conversions come from the generated
+            // FujiFilm::Main table, so FilmMode 1536 prints as "Classic Chrome".
+            // ExifTool: lib/Image/ExifTool/FujiFilm.pm %Image::ExifTool::FujiFilm::Main
+            if let Some(tag_def) = fujifilm_tag_kit::FUJI_FILM_MAIN_TAGS.get(&tag_id) {
+                if tag_def.value_conv.is_some() {
+                    let mut value_conv_errors = Vec::new();
+                    match fujifilm_tag_kit::apply_value_conv(
+                        tag_id as u32,
+                        &value,
+                        &mut value_conv_errors,
+                    ) {
+                        Ok(converted) => value = converted,
+                        Err(e) => debug!(
+                            "Failed to apply ValueConv to FujiFilm tag 0x{:04x}: {}",
+                            tag_id, e
+                        ),
+                    }
+                }
+
+                let mut errors = Vec::new();
+                let mut warnings = Vec::new();
+                let print = fujifilm_tag_kit::apply_print_conv(
+                    tag_id as u32,
+                    &value,
+                    &mut errors,
+                    &mut warnings,
+                );
+
+                (value, print)
+            } else {
+                debug!("FujiFilm tag 0x{:04x} not in FUJI_FILM_MAIN_TAGS", tag_id);
                 (value.clone(), value)
             }
         } else if ifd_name == "Sony"

--- a/tests/fujifilm_makernotes_test.rs
+++ b/tests/fujifilm_makernotes_test.rs
@@ -1,0 +1,190 @@
+//! FujiFilm MakerNotes dispatch and offset handling.
+//!
+//! The generated FujiFilm tables (src/generated/FujiFilm_pm/) carry the whole
+//! Main table, PrintConvs included, but nothing reached them: the dispatch in
+//! process_maker_notes_with_signature_detection branched on Make for Canon,
+//! Olympus and Sony and sent everything else down the generic path, which reads
+//! the subdirectory as a plain TIFF IFD. A Fuji file came back with every tag
+//! named Tag_1401 rather than FilmMode.
+//!
+//! ExifTool: lib/Image/ExifTool/MakerNotes.pm:121-134 (MakerNoteFujiFilm).
+//!
+//! These are synthetic files rather than fixtures because each one pins a
+//! separate way the subdirectory can be read wrongly while still parsing.
+
+use exif_oxide::exif::ExifReader;
+
+/// Offset of the MakerNotes value inside the synthetic TIFF below.
+const MAKERNOTE_OFFSET: u32 = 48;
+
+/// Where the FujiFilm IFD sits inside the MakerNotes block.
+///
+/// Deliberately 16 rather than the 12 every X-series body writes: the value is
+/// a POINTER stored at byte 8 (ExifTool: OffsetPt => '$valuePtr+8'), so an
+/// implementation that hardcodes a skip passes on real files and fails here.
+const IFD_POINTER: u32 = 16;
+
+/// Build a little-endian TIFF whose IFD0 carries the given Make and a
+/// MakerNotes (0x927C) block with the given 8-byte signature.
+///
+/// The MakerNotes block holds three entries chosen to cover the three ways this
+/// subdirectory differs from a plain IFD:
+///   0x1401 FilmMode      SHORT, inline   -> needs the generated PrintConv
+///   0x1040 ShadowTone    SLONG, inline   -> a format the old Fuji reader dropped
+///   0x1000 Quality       ASCII, indirect -> needs Base => '$start'
+fn fujifilm_tiff(make: &[u8], signature: &[u8; 8]) -> Vec<u8> {
+    let mut d = Vec::new();
+
+    // TIFF header: little-endian, magic 42, IFD0 at offset 8
+    d.extend_from_slice(&[0x49, 0x49, 0x2A, 0x00, 0x08, 0x00, 0x00, 0x00]);
+
+    // IFD0: 2 entries
+    d.extend_from_slice(&2u16.to_le_bytes());
+    // Make (0x010F), ASCII, at offset 38
+    d.extend_from_slice(&0x010Fu16.to_le_bytes());
+    d.extend_from_slice(&2u16.to_le_bytes());
+    d.extend_from_slice(&(make.len() as u32).to_le_bytes());
+    d.extend_from_slice(&38u32.to_le_bytes());
+    // MakerNote (0x927C), UNDEFINED, at MAKERNOTE_OFFSET
+    d.extend_from_slice(&0x927Cu16.to_le_bytes());
+    d.extend_from_slice(&7u16.to_le_bytes());
+    d.extend_from_slice(&66u32.to_le_bytes());
+    d.extend_from_slice(&MAKERNOTE_OFFSET.to_le_bytes());
+    // No next IFD
+    d.extend_from_slice(&0u32.to_le_bytes());
+    assert_eq!(d.len(), 38);
+
+    // Offset 38: Make, padded out to the MakerNotes block
+    d.extend_from_slice(make);
+    while d.len() < MAKERNOTE_OFFSET as usize {
+        d.push(0);
+    }
+
+    // The MakerNotes block. Every offset from here on is relative to its start,
+    // which is the whole point of Base => '$start'.
+    let mut mn = Vec::new();
+    mn.extend_from_slice(signature); // +0
+    mn.extend_from_slice(&IFD_POINTER.to_le_bytes()); // +8: pointer to the IFD
+    mn.extend_from_slice(&[0xFF; 4]); // +12: filler the pointer skips over
+
+    // +16: the IFD itself, 3 entries
+    mn.extend_from_slice(&3u16.to_le_bytes());
+    // FilmMode = 1536 (Classic Chrome)
+    mn.extend_from_slice(&0x1401u16.to_le_bytes());
+    mn.extend_from_slice(&3u16.to_le_bytes());
+    mn.extend_from_slice(&1u32.to_le_bytes());
+    mn.extend_from_slice(&1536u32.to_le_bytes());
+    // ShadowTone = 32, SLONG (format 9)
+    mn.extend_from_slice(&0x1040u16.to_le_bytes());
+    mn.extend_from_slice(&9u16.to_le_bytes());
+    mn.extend_from_slice(&1u32.to_le_bytes());
+    mn.extend_from_slice(&32u32.to_le_bytes());
+    // Quality, ASCII, 8 bytes living at MakerNotes-relative offset 58
+    mn.extend_from_slice(&0x1000u16.to_le_bytes());
+    mn.extend_from_slice(&2u16.to_le_bytes());
+    mn.extend_from_slice(&8u32.to_le_bytes());
+    mn.extend_from_slice(&58u32.to_le_bytes());
+    // No next IFD
+    mn.extend_from_slice(&0u32.to_le_bytes());
+    assert_eq!(mn.len(), 58);
+
+    // +58: the Quality string. Read TIFF-relative instead of
+    // MakerNotes-relative, offset 58 lands back in IFD0 and this test fails
+    // with a garbage string rather than an error.
+    mn.extend_from_slice(b"FINE   \0");
+    assert_eq!(mn.len(), 66);
+
+    d.extend_from_slice(&mn);
+    d
+}
+
+/// Read one MakerNotes tag's print value.
+fn print_value(data: &[u8], name: &str) -> Option<String> {
+    let mut reader = ExifReader::new();
+    reader.parse_exif_data(data).expect("parse");
+    reader
+        .get_all_tag_entries()
+        .into_iter()
+        .find(|e| e.name == name && e.group == "MakerNotes")
+        .map(|e| e.print.to_string())
+}
+
+#[test]
+fn test_fujifilm_tags_are_named_from_the_generated_table() {
+    let data = fujifilm_tiff(b"FUJIFILM\0", b"FUJIFILM");
+    assert_eq!(
+        print_value(&data, "FilmMode").as_deref(),
+        Some("Classic Chrome"),
+        "FilmMode 1536 should resolve through FUJI_FILM_MAIN_TAGS"
+    );
+}
+
+#[test]
+fn test_fujifilm_ifd_pointer_is_read_rather_than_assumed() {
+    // IFD_POINTER is 16 here. An implementation that treats the IFD as starting
+    // at signature+8 reads the pointer bytes as an entry count and finds
+    // nothing, so the absence of FilmMode is the failure signal.
+    // ExifTool: MakerNotes.pm:128 OffsetPt => '$valuePtr+8'
+    let data = fujifilm_tiff(b"FUJIFILM\0", b"FUJIFILM");
+    assert!(
+        print_value(&data, "FilmMode").is_some(),
+        "IFD pointer at byte 8 was not followed"
+    );
+}
+
+#[test]
+fn test_fujifilm_value_offsets_are_subdirectory_relative() {
+    // ExifTool: MakerNotes.pm:131 Base => '$start'
+    // Inline values survive a wrong base, so an out-of-line string is the only
+    // thing that tells the two apart.
+    let data = fujifilm_tiff(b"FUJIFILM\0", b"FUJIFILM");
+    let quality = print_value(&data, "Quality").expect("Quality should be extracted");
+    assert!(
+        quality.starts_with("FINE"),
+        "Quality read against the wrong base: {quality:?}"
+    );
+}
+
+#[test]
+fn test_fujifilm_slong_tags_are_extracted() {
+    // HighlightTone, ShadowTone, GrainEffectRoughness, ColorChromeEffect and
+    // ColorChromeFXBlue are all SLONG, so a reader handling only BYTE/ASCII/
+    // SHORT/LONG drops most of the film recipe.
+    let data = fujifilm_tiff(b"FUJIFILM\0", b"FUJIFILM");
+    assert_eq!(
+        print_value(&data, "ShadowTone").as_deref(),
+        Some("-2 (soft)")
+    );
+}
+
+#[test]
+fn test_fujifilm_dispatch_is_on_signature_not_make() {
+    // ExifTool: MakerNotes.pm:122 — the FUJIFILM header is also written by some
+    // Leica, Minolta and Sharp bodies, so Make is the wrong discriminator.
+    let data = fujifilm_tiff(b"LEICA\0", b"FUJIFILM");
+    assert_eq!(
+        print_value(&data, "FilmMode").as_deref(),
+        Some("Classic Chrome"),
+        "a FUJIFILM signature under a non-Fuji Make was not dispatched"
+    );
+}
+
+#[test]
+fn test_generale_signature_is_dispatched() {
+    // ExifTool: MakerNotes.pm:124 Condition => '$$valPt =~ /^(FUJIFILM|GENERALE)/'
+    let data = fujifilm_tiff(b"GE\0", b"GENERALE");
+    assert_eq!(
+        print_value(&data, "FilmMode").as_deref(),
+        Some("Classic Chrome")
+    );
+}
+
+#[test]
+fn test_truncated_fujifilm_makernotes_is_a_warning_not_a_panic() {
+    // The MakerNotes length is attacker-controlled, so every read past the
+    // header is bounds checked (fuzz_exif_ifd).
+    let mut data = fujifilm_tiff(b"FUJIFILM\0", b"FUJIFILM");
+    data.truncate(MAKERNOTE_OFFSET as usize + 10);
+    let mut reader = ExifReader::new();
+    let _ = reader.parse_exif_data(&data);
+}


### PR DESCRIPTION
Fixes #30.

`src/generated/FujiFilm_pm/` already holds the whole `FujiFilm::Main` table with its PrintConvs. Nothing reached it, so every Fuji tag came out as `Tag_XXXX` and a few came out with Canon's names. This wires the dispatch up; no ExifTool data is ported by hand and no generated file changes.

### Result

43 FujiFilm JPEGs from an X-T50, MakerNotes group compared against `exiftool -j -G`:

| | agree | disagree | only exiftool |
|---|--:|--:|--:|
| main (`91b22ac`) | 0 | 0 | 2548 |
| this branch | 1589 | 452 | 507 |

Nothing matched before because no name resolved. One file, before and after:

```
- "MakerNotes:Tag_1401": 1536,          + "MakerNotes:FilmMode": "Classic Chrome",
- "MakerNotes:Tag_1400": 1,             + "MakerNotes:DynamicRange": "Standard",
- "MakerNotes:Tag_1000": "",            + "MakerNotes:Quality": "FINE",
- "MakerNotes:CanonCameraSettings": …   + "MakerNotes:InternalSerialNumber": "FF02B8045287…",
                                        + "MakerNotes:ShadowTone": "-2 (soft)",
                                        + "MakerNotes:ColorChromeEffect": "Strong",
```

### What changed

Everything here follows `MakerNotes.pm:121-134`, cited at the code.

**`src/exif/ifd.rs`** gets a FujiFilm branch and a reader for the subdirectory.

Dispatch is on the **data signature**, never on Make, per `MakerNotes.pm:122-124`: the FUJIFILM header is also written by some Leica, Minolta and Sharp bodies, and GE bodies write GENERALE.

`OffsetPt => '$valuePtr+8'` is a pointer to the IFD rather than a skip. It reads 12 on every X-series file I have, and it is not a constant, so a test pins a file with 16.

`Base => '$start'` is why this parses from the MakerNotes slice instead of calling `parse_ifd`: `value_extraction` resolves `value_or_offset` against whatever slice it is handed, so passing the subdirectory makes the base right by construction. This one is worth flagging for review, since it is the choice most open to a different opinion. The alternative is to give `parse_ifd` a base parameter, which is more general (Nikon and Pentax want it too) and touches a path every manufacturer shares. I took the contained option because this is my first patch here; say the word and I will do it the other way.

The value reader also covers SLONG and SSHORT, which the old Fuji code did not. `ShadowTone`, `HighlightTone`, `GrainEffectRoughness`, `ColorChromeEffect` and `ColorChromeFXBlue` are all SLONG, so most of the film recipe depended on it.

**`src/exif/tags.rs`** applies `FujiFilm_pm::main_tags::{apply_value_conv, apply_print_conv}` for the namespace, mirroring the Sony arm exactly.

**`src/exif/mod.rs`** resolves names from `FUJI_FILM_MAIN_TAGS` in both name paths, and adds FujiFilm to `should_lookup_global` so Fuji tag IDs stop being looked up in the global EXIF/GPS table.

The namespace is spelled `FujiFilm` to match ExifTool's group1 (`exiftool -G1` gives `FujiFilm:FilmMode`). The four `"Fujifilm"` spellings already in the tree could never match a group name, and they move with it.

### Tests

`tests/fujifilm_makernotes_test.rs`, 7 tests, synthetic files in the style of `makernote_recursion_test.rs`. Each pins one way the subdirectory can be read wrongly **while still parsing**, which is what made all of this silent: the IFD pointer being followed rather than assumed, value offsets being subdirectory-relative (an out-of-line ASCII value is the only thing that can tell the two bases apart), SLONG extraction, dispatch on signature under a `LEICA` Make, the GENERALE signature, and a truncated block staying a warning.

I did not add an image fixture, since the failure modes are all expressible in synthetic bytes and a real Fuji JPEG is 22 MB.

### Not in scope

- **The AF, Focus and Drive subdirectories.** Those account for most of the 507 tags exiftool still reports and this does not. The generated tables exist (`focus_settings_tags.rs`, `afc_settings_tags.rs`, `drive_settings_tags.rs`), so it is a follow-up of the same kind.
- **Complex PrintConvs.** `InternalSerialNumber`, `ImageStabilization`, `FlickerReduction` and `FocusPixel` are unimplemented in the generated table, so their raw values come through. That belongs in codegen.
- **Rendering conventions**, which are crate-wide rather than Fuji. `MinFocalLength` prints `35.0` against exiftool's `35`, and UNDEFINED prints as a byte array. Both show up in the EXIF group on the same file on main (`EXIF:ExposureCompensation` is `0.0` against `0`, `EXIF:ComponentsConfiguration` is `[1,2,3,0]` against `Y, Cb, Cr, -`), so they predate this change.

### Checks

`cargo fmt --check` clean. `cargo test --release` is 501 passed, 11 failed; all 11 are in `cli_tag_filtering_integration_test.rs` and every one of them uses `TEST_IMAGE_CANON` (`test-images/canon/eos_rebel_t3i.jpg`), which is fetched by a Makefile target rather than committed. The 5 tests in that file using the `third-party/exiftool` Ricoh image pass. On unpatched main in a worktree without the corpus, all 16 fail.
