### PR TITLE
feat(heif): extract the EXIF item from ISO BMFF containers

### DIFF
--- a/src/formats/avif.rs
+++ b/src/formats/avif.rs
@@ -383,19 +383,28 @@ fn parse_infe_box(infe_data: &[u8]) -> Result<ItemInfo> {
 
     let version = infe_data[0];
 
-    let (item_id, item_type_offset) = if version == 0 || version == 1 {
-        // Version 0/1: 16-bit item ID at offset 4
+    // The item ID is 16-bit in versions 0, 1 and 2, and 32-bit only in version 3.
+    // ExifTool: QuickTime.pm:9246-9256 (ParseItemInfoEntry) — `$ver == 2` takes
+    // Get16u and `$ver == 3` takes Get32u.
+    //
+    // Reading version 2 as 32-bit made every real HEIC and HEIF file fail here.
+    // Fuji, Apple and Canon all write version 2 entries, whose box content is 13
+    // bytes, so the old `len() < 14` guard rejected each one outright: a 10-entry
+    // iinf box yielded 1 item, the Exif item was never seen, and the file came
+    // back with no EXIF at all.
+    let (item_id, item_type_offset) = if version <= 2 {
+        // Version 0/1/2: 16-bit item ID at offset 4
         let id = u16::from_be_bytes([infe_data[4], infe_data[5]]) as u32;
-        (id, 8) // Skip version/flags (4) + item_id (2) + protection_index (2)
+        (id, 8) // version/flags (4) + item_id (2) + protection_index (2)
     } else {
-        // Version 2+: 32-bit item ID at offset 4
+        // Version 3: 32-bit item ID at offset 4
         if infe_data.len() < 14 {
             return Err(crate::types::ExifError::InvalidFormat(
-                "infe box too short for version 2+ item ID".to_string(),
+                "infe box too short for version 3 item ID".to_string(),
             ));
         }
         let id = u32::from_be_bytes([infe_data[4], infe_data[5], infe_data[6], infe_data[7]]);
-        (id, 10) // Skip version/flags (4) + item_id (4) + protection_index (2)
+        (id, 10) // version/flags (4) + item_id (4) + protection_index (2)
     };
 
     // Extract item type (4 bytes ASCII)
@@ -553,6 +562,303 @@ pub fn parse_ipma_box(ipma_data: &[u8]) -> Result<Vec<ItemPropertyAssociation>> 
     }
 
     Ok(associations)
+}
+
+/// One extent of an item's data, from the 'iloc' box.
+///
+/// ExifTool: QuickTime.pm:9127-9195 (ParseItemLocation), ISO 14496-12:2015 pg.79
+#[derive(Debug, Clone)]
+pub struct ItemExtent {
+    pub offset: u64,
+    pub length: u64,
+}
+
+/// Where one item's bytes live.
+#[derive(Debug, Clone)]
+pub struct ItemLocation {
+    pub item_id: u32,
+    pub construction_method: u8,
+    pub base_offset: u64,
+    pub extents: Vec<ItemExtent>,
+}
+
+/// Read a big-endian integer of `size` bytes.
+///
+/// ExifTool: QuickTime.pm GetVarInt. A size of 0 means the field is absent and
+/// reads as 0, which is why base offsets are usually 0 in HEIC files.
+fn read_var_int(data: &[u8], pos: &mut usize, size: usize) -> Option<u64> {
+    if size == 0 {
+        return Some(0);
+    }
+    if size > 8 || *pos + size > data.len() {
+        return None;
+    }
+    let mut value: u64 = 0;
+    for byte in &data[*pos..*pos + size] {
+        value = (value << 8) | u64::from(*byte);
+    }
+    *pos += size;
+    Some(value)
+}
+
+/// Parse the 'iloc' (item location) box.
+///
+/// ExifTool: QuickTime.pm:9127-9195 (ParseItemLocation)
+///
+/// The field WIDTHS are themselves stored in the box: one packed u16 holds four
+/// nibbles giving the byte size of the offset, length, base-offset and index
+/// fields, so the entry stride is per-file rather than fixed.
+pub fn parse_iloc_box(iloc_data: &[u8]) -> Result<Vec<ItemLocation>> {
+    if iloc_data.len() < 8 {
+        return Err(crate::types::ExifError::InvalidFormat(
+            "iloc box too short".to_string(),
+        ));
+    }
+
+    let version = iloc_data[0];
+    // Bytes 1..4 are flags. Bytes 4..6 pack the four field widths.
+    let sizes = u16::from_be_bytes([iloc_data[4], iloc_data[5]]);
+    let offset_size = (sizes >> 12) as usize;
+    let length_size = ((sizes >> 8) & 0x0f) as usize;
+    let base_size = ((sizes >> 4) & 0x0f) as usize;
+    let index_size = (sizes & 0x0f) as usize;
+
+    let (item_count, mut pos) = if version < 2 {
+        (u16::from_be_bytes([iloc_data[6], iloc_data[7]]) as u32, 8)
+    } else {
+        if iloc_data.len() < 10 {
+            return Err(crate::types::ExifError::InvalidFormat(
+                "iloc box too short for version 2 item count".to_string(),
+            ));
+        }
+        (
+            u32::from_be_bytes([iloc_data[6], iloc_data[7], iloc_data[8], iloc_data[9]]),
+            10,
+        )
+    };
+
+    tracing::debug!(
+        "iloc box: version={}, items={}, offset_size={}, length_size={}, base_size={}",
+        version,
+        item_count,
+        offset_size,
+        length_size,
+        base_size
+    );
+
+    let mut locations = Vec::new();
+
+    for _ in 0..item_count {
+        let item_id = if version < 2 {
+            if pos + 2 > iloc_data.len() {
+                break;
+            }
+            let id = u16::from_be_bytes([iloc_data[pos], iloc_data[pos + 1]]) as u32;
+            pos += 2;
+            id
+        } else {
+            if pos + 4 > iloc_data.len() {
+                break;
+            }
+            let id = u32::from_be_bytes([
+                iloc_data[pos],
+                iloc_data[pos + 1],
+                iloc_data[pos + 2],
+                iloc_data[pos + 3],
+            ]);
+            pos += 4;
+            id
+        };
+
+        // Construction method only exists in versions 1 and 2.
+        let construction_method = if version == 1 || version == 2 {
+            if pos + 2 > iloc_data.len() {
+                break;
+            }
+            let method = (u16::from_be_bytes([iloc_data[pos], iloc_data[pos + 1]]) & 0x0f) as u8;
+            pos += 2;
+            method
+        } else {
+            0
+        };
+
+        // A non-zero data reference index means the bytes live in another file,
+        // which ExifTool declines to follow (QuickTime.pm:9388 "Not this file").
+        if pos + 2 > iloc_data.len() {
+            break;
+        }
+        let data_reference_index = u16::from_be_bytes([iloc_data[pos], iloc_data[pos + 1]]);
+        pos += 2;
+
+        let base_offset = match read_var_int(iloc_data, &mut pos, base_size) {
+            Some(value) => value,
+            None => break,
+        };
+
+        if pos + 2 > iloc_data.len() {
+            break;
+        }
+        let extent_count = u16::from_be_bytes([iloc_data[pos], iloc_data[pos + 1]]);
+        pos += 2;
+
+        let mut extents = Vec::new();
+        let mut truncated = false;
+        for _ in 0..extent_count {
+            if (version == 1 || version == 2)
+                && read_var_int(iloc_data, &mut pos, index_size).is_none()
+            {
+                truncated = true;
+                break;
+            }
+            let offset = match read_var_int(iloc_data, &mut pos, offset_size) {
+                Some(value) => value,
+                None => {
+                    truncated = true;
+                    break;
+                }
+            };
+            let length = match read_var_int(iloc_data, &mut pos, length_size) {
+                Some(value) => value,
+                None => {
+                    truncated = true;
+                    break;
+                }
+            };
+            extents.push(ItemExtent { offset, length });
+        }
+
+        if data_reference_index == 0 {
+            locations.push(ItemLocation {
+                item_id,
+                construction_method,
+                base_offset,
+                extents,
+            });
+        }
+
+        if truncated {
+            break;
+        }
+    }
+
+    Ok(locations)
+}
+
+/// The EXIF payload of an ISO BMFF file, ready for the TIFF parser.
+#[derive(Debug, Clone)]
+pub struct ExifItem {
+    /// TIFF bytes, starting at the "II*\0" or "MM\0*" header.
+    pub tiff_data: Vec<u8>,
+    /// Absolute position of those bytes in the file, for IsOffset adjustment.
+    pub tiff_offset: u64,
+}
+
+/// Extract the EXIF item from a HEIF, HEIC or AVIF file.
+///
+/// ExifTool: QuickTime.pm:9345-9483 (HandleItemInfo). The item whose iinf type
+/// is "Exif" holds the EXIF, iloc says where its bytes are, and the payload
+/// carries a header in front of the TIFF data (see below).
+///
+/// Returns Ok(None) when the file has no EXIF item, which is an ordinary state
+/// for an AVIF and is deliberately not an error.
+pub fn extract_exif_item(data: &[u8]) -> Result<Option<ExifItem>> {
+    let Some(meta_box) = find_box_by_type(data, b"meta")? else {
+        return Ok(None);
+    };
+
+    // meta is a FullBox: 4 bytes of version and flags before its children.
+    let meta_content = if meta_box.data.len() >= 4 {
+        &meta_box.data[4..]
+    } else {
+        return Ok(None);
+    };
+
+    let Some(iinf_box) = find_box_by_type(meta_content, b"iinf")? else {
+        return Ok(None);
+    };
+    let items = parse_iinf_box(&iinf_box.data)?;
+
+    // ExifTool: QuickTime.pm:9371 maps the item type "Exif" to its EXIF handler.
+    let Some(exif_item) = items.iter().find(|item| &item.item_type == b"Exif") else {
+        tracing::debug!("No Exif item in iinf box");
+        return Ok(None);
+    };
+
+    let Some(iloc_box) = find_box_by_type(meta_content, b"iloc")? else {
+        tracing::debug!("Exif item present but no iloc box to locate it");
+        return Ok(None);
+    };
+    let locations = parse_iloc_box(&iloc_box.data)?;
+
+    let Some(location) = locations
+        .iter()
+        .find(|loc| loc.item_id == exif_item.item_id)
+    else {
+        tracing::debug!("No iloc entry for Exif item {}", exif_item.item_id);
+        return Ok(None);
+    };
+
+    // ExifTool: QuickTime.pm:9385 declines construction methods above 0, and
+    // method 1 (data in 'idat') needs a box this does not read yet.
+    if location.construction_method != 0 {
+        tracing::debug!(
+            "Exif item uses construction method {}, not extracted",
+            location.construction_method
+        );
+        return Ok(None);
+    }
+
+    // ExifTool: QuickTime.pm:9435-9441 concatenates every extent.
+    let mut payload = Vec::new();
+    let mut payload_start = None;
+    for extent in &location.extents {
+        let start = location.base_offset.saturating_add(extent.offset);
+        let end = start.saturating_add(extent.length);
+        if end > data.len() as u64 {
+            tracing::debug!("Exif extent {}..{} is past the end of the file", start, end);
+            return Ok(None);
+        }
+        if payload_start.is_none() {
+            payload_start = Some(start);
+        }
+        payload.extend_from_slice(&data[start as usize..end as usize]);
+    }
+
+    let Some(payload_start) = payload_start else {
+        return Ok(None);
+    };
+    if payload.len() < 4 {
+        return Ok(None);
+    }
+
+    // ExifTool: QuickTime.pm:9462-9481. The payload normally opens with a
+    // 4-byte big-endian count of bytes to skip before the TIFF header, and that
+    // count is usually 6 because an "Exif\0\0" header follows it. Two malformed
+    // shapes are common enough that ExifTool names both.
+    let start = if payload.starts_with(b"MM\0\x2a") || payload.starts_with(b"II\x2a\0") {
+        // Missing Exif header: the TIFF header is already at byte 0.
+        0
+    } else if payload.starts_with(b"Exif\0\0") {
+        // Missing Exif header size.
+        6
+    } else {
+        let skip = u32::from_be_bytes([payload[0], payload[1], payload[2], payload[3]]) as usize;
+        let start = 4 + skip;
+        if start > payload.len() {
+            tracing::debug!(
+                "Invalid EXIF header: skip {} past {} bytes",
+                skip,
+                payload.len()
+            );
+            return Ok(None);
+        }
+        start
+    };
+
+    Ok(Some(ExifItem {
+        tiff_data: payload[start..].to_vec(),
+        tiff_offset: payload_start + start as u64,
+    }))
 }
 
 /// Extract HEIC/HEIF image dimensions using ExifTool's primary item detection

--- a/src/formats/mod.rs
+++ b/src/formats/mod.rs
@@ -13,8 +13,9 @@ mod quicktime;
 mod tiff;
 
 pub use avif::{
-    create_avif_tag_entries, extract_avif_dimensions, extract_heic_dimensions_primary_item,
-    parse_box_header, AvifImageProperties, IsoBox,
+    create_avif_tag_entries, extract_avif_dimensions, extract_exif_item,
+    extract_heic_dimensions_primary_item, parse_box_header, parse_iloc_box, AvifImageProperties,
+    ExifItem, IsoBox, ItemExtent, ItemLocation,
 };
 pub use detection::{
     detect_file_format, detect_file_format_from_path, get_format_properties, FileFormat,
@@ -1170,6 +1171,15 @@ pub fn extract_metadata(
                                 );
                             }
                         }
+
+                        // An AVIF may carry EXIF in the same meta/iinf/iloc
+                        // structure a HEIC does, so the extraction is shared.
+                        append_iso_bmff_exif(
+                            &avif_data,
+                            &mut tag_entries,
+                            &mut tags,
+                            show_warnings,
+                        );
                     }
                     "HEIC" | "HEIF" => {
                         // HEIC/HEIF format processing - extract dimensions from ispe box
@@ -1234,6 +1244,17 @@ pub fn extract_metadata(
                                 );
                             }
                         }
+
+                        // The dimensions above come from image properties. The
+                        // EXIF is a separate item in the same meta box, and
+                        // until this call nothing read it: a Fuji .HIF returned
+                        // 17 tags with no camera, lens, exposure or MakerNotes.
+                        append_iso_bmff_exif(
+                            &file_data,
+                            &mut tag_entries,
+                            &mut tags,
+                            show_warnings,
+                        );
                     }
                     "MOV" | "MP4" => {
                         // QuickTime / MP4 container: streaming atom walker.
@@ -1442,6 +1463,69 @@ pub fn extract_metadata(
     exif_data.missing_implementations = missing_implementations;
 
     Ok(exif_data)
+}
+
+/// Pull the EXIF item out of an ISO BMFF file (HEIF, HEIC, AVIF) and fold its
+/// tags into the running collection.
+///
+/// ExifTool: QuickTime.pm:9345-9483 (HandleItemInfo)
+///
+/// A file with no EXIF item is normal and produces nothing here. A file whose
+/// EXIF item cannot be read records a warning rather than failing the
+/// extraction, because the File and Composite tags are still worth returning.
+fn append_iso_bmff_exif(
+    file_data: &[u8],
+    tag_entries: &mut Vec<TagEntry>,
+    tags: &mut indexmap::IndexMap<String, TagValue>,
+    show_warnings: bool,
+) {
+    let exif_item = match avif::extract_exif_item(file_data) {
+        Ok(Some(item)) => item,
+        Ok(None) => return,
+        Err(e) => {
+            tags.insert(
+                "Warning:IsoBmffExifError".to_string(),
+                TagValue::string(format!("Failed to locate EXIF item: {e}")),
+            );
+            return;
+        }
+    };
+
+    let mut exif_reader = ExifReader::new();
+
+    // The TIFF header sits at a real position in the file, and IsOffset tags
+    // (thumbnail offsets, most visibly) are stored TIFF-relative, so without
+    // this every such offset would point at the wrong bytes.
+    // ExifTool: Exif.pm:7052-7066
+    exif_reader.set_base_offset(exif_item.tiff_offset);
+
+    match exif_reader.parse_exif_data(&exif_item.tiff_data) {
+        Ok(()) => {
+            let mut exif_tag_entries = exif_reader.get_all_tag_entries();
+            tag_entries.append(&mut exif_tag_entries);
+
+            for (key, value) in exif_reader.get_all_tags() {
+                tags.insert(key, value);
+            }
+
+            add_exif_byte_order_tag(&exif_reader, tag_entries);
+
+            if show_warnings {
+                for (i, warning) in exif_reader.get_warnings().iter().enumerate() {
+                    tags.insert(
+                        format!("Warning:ExifWarning{i}"),
+                        TagValue::string(warning.clone()),
+                    );
+                }
+            }
+        }
+        Err(e) => {
+            tags.insert(
+                "Warning:IsoBmffExifError".to_string(),
+                TagValue::string(format!("Failed to parse EXIF item: {e}")),
+            );
+        }
+    }
 }
 
 /// Add ExifByteOrder tag based on TIFF header information

--- a/tests/heif_exif_test.rs
+++ b/tests/heif_exif_test.rs
@@ -1,0 +1,208 @@
+//! EXIF extraction from ISO BMFF containers (HEIF, HEIC, AVIF).
+//!
+//! Before this, a HEIF file produced dimensions and nothing else: the ispe box
+//! was read, and the EXIF item sitting in the same meta box was never located.
+//! A Fuji .HIF came back with 17 tags and no camera, lens or exposure at all.
+//!
+//! ExifTool: QuickTime.pm:9127-9195 (ParseItemLocation) and 9345-9483
+//! (HandleItemInfo).
+
+use exif_oxide::formats::{extract_exif_item, parse_iloc_box};
+
+/// Build a minimal HEIF holding one Exif item.
+///
+/// `infe_version` selects the item-ID width, which is the detail that broke
+/// every real file: versions 0, 1 and 2 store a 16-bit ID and only version 3
+/// stores a 32-bit one (ExifTool: QuickTime.pm:9246-9256).
+fn heif_with_exif(infe_version: u8, exif_payload: &[u8]) -> Vec<u8> {
+    fn boxed(box_type: &[u8; 4], body: &[u8]) -> Vec<u8> {
+        let mut b = Vec::new();
+        b.extend_from_slice(&((body.len() + 8) as u32).to_be_bytes());
+        b.extend_from_slice(box_type);
+        b.extend_from_slice(body);
+        b
+    }
+
+    const EXIF_ITEM_ID: u32 = 768;
+
+    // infe: version, 3 flag bytes, item ID, protection index, type
+    let mut infe = vec![infe_version, 0, 0, 0];
+    if infe_version <= 2 {
+        infe.extend_from_slice(&(EXIF_ITEM_ID as u16).to_be_bytes());
+    } else {
+        infe.extend_from_slice(&EXIF_ITEM_ID.to_be_bytes());
+    }
+    infe.extend_from_slice(&0u16.to_be_bytes()); // protection index
+    infe.extend_from_slice(b"Exif");
+    infe.push(0); // item name
+    let infe = boxed(b"infe", &infe);
+
+    // iinf version 0: 16-bit entry count, then the infe boxes
+    let mut iinf = vec![0, 0, 0, 0];
+    iinf.extend_from_slice(&1u16.to_be_bytes());
+    iinf.extend_from_slice(&infe);
+    let iinf = boxed(b"iinf", &iinf);
+
+    // iloc version 1, offsets and lengths 4 bytes wide, no base offset.
+    // The extent offset is absolute in the file, so the whole file has to be
+    // laid out before it can be filled in.
+    let mut iloc = vec![1u8, 0, 0, 0];
+    iloc.extend_from_slice(&0x4400u16.to_be_bytes()); // offset 4, length 4, base 0, index 0
+    iloc.extend_from_slice(&1u16.to_be_bytes()); // item count
+    iloc.extend_from_slice(&(EXIF_ITEM_ID as u16).to_be_bytes());
+    iloc.extend_from_slice(&0u16.to_be_bytes()); // construction method 0 (file offset)
+    iloc.extend_from_slice(&0u16.to_be_bytes()); // data reference index
+    iloc.extend_from_slice(&1u16.to_be_bytes()); // extent count
+    let offset_patch_at = iloc.len();
+    iloc.extend_from_slice(&0u32.to_be_bytes()); // extent offset, patched below
+    iloc.extend_from_slice(&(exif_payload.len() as u32).to_be_bytes());
+    let iloc = boxed(b"iloc", &iloc);
+
+    // meta is a FullBox: 4 bytes of version and flags before its children
+    let mut meta = vec![0, 0, 0, 0];
+    meta.extend_from_slice(&iinf);
+    let iloc_start_in_meta = meta.len();
+    meta.extend_from_slice(&iloc);
+    let meta = boxed(b"meta", &meta);
+
+    let mut ftyp = Vec::new();
+    ftyp.extend_from_slice(b"heix");
+    ftyp.extend_from_slice(&0u32.to_be_bytes());
+    ftyp.extend_from_slice(b"mif1heix");
+    let ftyp = boxed(b"ftyp", &ftyp);
+
+    let mut file = Vec::new();
+    file.extend_from_slice(&ftyp);
+    let meta_start = file.len();
+    file.extend_from_slice(&meta);
+    let payload_offset = file.len() as u32;
+    file.extend_from_slice(exif_payload);
+
+    // Patch the extent offset now that the payload's position is known.
+    // iloc_start_in_meta is measured inside the meta BODY, which already
+    // includes its 4 version/flags bytes, so only the two box headers are added.
+    let patch = meta_start + 8 + iloc_start_in_meta + 8 + offset_patch_at;
+    file[patch..patch + 4].copy_from_slice(&payload_offset.to_be_bytes());
+
+    file
+}
+
+/// A TIFF holding a single IFD0 entry: Make = "FUJIFILM".
+fn tiff_with_make() -> Vec<u8> {
+    let mut d = Vec::new();
+    d.extend_from_slice(&[0x49, 0x49, 0x2A, 0x00, 0x08, 0x00, 0x00, 0x00]);
+    d.extend_from_slice(&1u16.to_le_bytes());
+    d.extend_from_slice(&0x010Fu16.to_le_bytes());
+    d.extend_from_slice(&2u16.to_le_bytes());
+    d.extend_from_slice(&9u32.to_le_bytes());
+    d.extend_from_slice(&26u32.to_le_bytes());
+    d.extend_from_slice(&0u32.to_le_bytes());
+    d.extend_from_slice(b"FUJIFILM\0");
+    d
+}
+
+/// The usual payload shape: a 4-byte big-endian skip count, then "Exif\0\0",
+/// then the TIFF header. ExifTool: QuickTime.pm:9471-9473.
+fn exif_payload(tiff: &[u8]) -> Vec<u8> {
+    let mut payload = Vec::new();
+    payload.extend_from_slice(&6u32.to_be_bytes());
+    payload.extend_from_slice(b"Exif\0\0");
+    payload.extend_from_slice(tiff);
+    payload
+}
+
+#[test]
+fn test_exif_item_is_found_in_a_heif() {
+    let file = heif_with_exif(2, &exif_payload(&tiff_with_make()));
+    let item = extract_exif_item(&file)
+        .expect("parse")
+        .expect("an Exif item");
+    assert!(
+        item.tiff_data.starts_with(b"II\x2a\0"),
+        "payload header was not skipped: {:?}",
+        &item.tiff_data[..4.min(item.tiff_data.len())]
+    );
+    assert_eq!(
+        item.tiff_offset as usize + item.tiff_data.len(),
+        file.len(),
+        "tiff_offset must be the payload's real position in the file"
+    );
+}
+
+#[test]
+fn test_infe_version_2_uses_a_16_bit_item_id() {
+    // ExifTool: QuickTime.pm:9246-9256. Reading version 2 as 32-bit is what made
+    // every real HEIC and HEIF fail: the entry is 13 bytes of content, a 32-bit
+    // read needs 14, so the item was discarded and no Exif item was ever seen.
+    let file = heif_with_exif(2, &exif_payload(&tiff_with_make()));
+    assert!(
+        extract_exif_item(&file).expect("parse").is_some(),
+        "a version 2 infe entry was not read"
+    );
+}
+
+#[test]
+fn test_infe_version_3_uses_a_32_bit_item_id() {
+    let file = heif_with_exif(3, &exif_payload(&tiff_with_make()));
+    assert!(
+        extract_exif_item(&file).expect("parse").is_some(),
+        "a version 3 infe entry was not read"
+    );
+}
+
+#[test]
+fn test_payload_without_the_exif_header_is_accepted() {
+    // ExifTool: QuickTime.pm:9463-9464 warns "Missing Exif header" and treats
+    // the payload as starting at the TIFF header.
+    let file = heif_with_exif(2, &tiff_with_make());
+    let item = extract_exif_item(&file)
+        .expect("parse")
+        .expect("an Exif item");
+    assert!(item.tiff_data.starts_with(b"II\x2a\0"));
+}
+
+#[test]
+fn test_a_file_with_no_exif_item_is_not_an_error() {
+    // An AVIF with no EXIF is ordinary, so this reports absence rather than
+    // failing the whole extraction.
+    let mut file = heif_with_exif(2, &exif_payload(&tiff_with_make()));
+    // Turn the item type into something that is not Exif.
+    let pos = file
+        .windows(4)
+        .position(|w| w == b"Exif")
+        .expect("the item type");
+    file[pos..pos + 4].copy_from_slice(b"hvc1");
+    assert!(extract_exif_item(&file).expect("parse").is_none());
+}
+
+#[test]
+fn test_iloc_field_widths_come_from_the_box() {
+    // The nibbles at bytes 4..6 give the byte width of the offset, length,
+    // base-offset and index fields, so the stride is per-file.
+    // ExifTool: QuickTime.pm:9142-9146
+    let mut iloc = vec![1u8, 0, 0, 0];
+    iloc.extend_from_slice(&0x4400u16.to_be_bytes());
+    iloc.extend_from_slice(&1u16.to_be_bytes());
+    iloc.extend_from_slice(&7u16.to_be_bytes()); // item ID
+    iloc.extend_from_slice(&0u16.to_be_bytes()); // construction method
+    iloc.extend_from_slice(&0u16.to_be_bytes()); // data reference index
+    iloc.extend_from_slice(&1u16.to_be_bytes()); // extent count
+    iloc.extend_from_slice(&0x1234u32.to_be_bytes());
+    iloc.extend_from_slice(&0x40u32.to_be_bytes());
+
+    let locations = parse_iloc_box(&iloc).expect("parse");
+    assert_eq!(locations.len(), 1);
+    assert_eq!(locations[0].item_id, 7);
+    assert_eq!(locations[0].extents.len(), 1);
+    assert_eq!(locations[0].extents[0].offset, 0x1234);
+    assert_eq!(locations[0].extents[0].length, 0x40);
+}
+
+#[test]
+fn test_truncated_boxes_do_not_panic() {
+    let file = heif_with_exif(2, &exif_payload(&tiff_with_make()));
+    for cut in [12, 30, 48, 70, file.len() - 4] {
+        let _ = extract_exif_item(&file[..cut]);
+    }
+    let _ = parse_iloc_box(&[1, 0, 0, 0, 0x44, 0x00, 0, 1]);
+}


### PR DESCRIPTION
A HEIF, HEIC or AVIF file produced dimensions and nothing else. The `ispe` box was read and the EXIF item sitting in the same `meta` box was never located, so a Fujifilm `.HIF` came back with **17 tags and no camera, lens, exposure or MakerNotes at all**.

```
$ exif-oxide XT500010.HIF        # main
17 tags: SourceFile, ExifToolVersion, System:HEIFDetectionStatus,
         12 File: tags, Composite:ImageSize, Composite:Megapixels

$ exif-oxide XT500010.HIF        # this branch
170 tags, including:
  "EXIF:Make": "FUJIFILM",  "EXIF:Model": "X-T50",
  "EXIF:LensModel": "XF35mmF1.4 R",
  "EXIF:ExposureTime": "1/500",  "EXIF:FNumber": 8.0,  "EXIF:ISO": 640,
```

Across 20 Fujifilm `.HIF` files, EXIF group against `exiftool -j -G`: **1100 agree, 220 disagree, 0 that exiftool finds and this does not.**

### Two things were missing

**1. Nothing walked `iloc`.** `avif.rs` already had `meta`, `pitm`, `iinf` and `ipma`, which is everything needed to find *which* item holds the EXIF and nothing to say *where* its bytes are. `parse_iloc_box` follows QuickTime.pm:9127-9195. The part worth knowing is that the field widths are themselves stored in the box: one packed u16 holds four nibbles giving the byte size of the offset, length, base-offset and index fields, so the entry stride is per-file rather than fixed.

`extract_exif_item` then follows QuickTime.pm:9345-9483: find the item whose `iinf` type is `Exif`, concatenate its extents, and skip the payload header. That header is the other quiet detail, QuickTime.pm:9462-9481: the payload normally opens with a 4-byte big-endian count of bytes to skip, usually 6 because an `Exif\0\0` header follows, and ExifTool names two malformed shapes that turn up in the wild (a bare TIFF header, and `Exif\0\0` with no count). All three are handled.

Construction method 1 (data in `idat`) returns `None` with a debug line rather than a wrong answer, matching QuickTime.pm:9386. A file with no EXIF item is not an error, since that is ordinary for an AVIF.

**2. `parse_infe_box` read version 2 as a 32-bit item ID, and that alone broke every real file.** Per QuickTime.pm:9246-9256, versions 0, 1 and 2 store a **16-bit** item ID and only version 3 stores 32-bit. Fuji, Apple and Canon all write version 2, whose box content is 13 bytes, so the `len() < 14` guard rejected each entry outright:

```
iinf box: version=0, entry_count=10
Found 1 items in iinf box        <- the one 42-byte 'mime' entry
No Exif item in iinf box
```

Ten items in the file, one parsed, and the Exif item among the nine discarded. This is a bug in code that already shipped: `extract_heic_dimensions_primary_item` has been running against that same truncated item list.

### Wiring

`append_iso_bmff_exif` folds the item's tags in, and both the AVIF and the HEIC/HEIF arms call it, because an AVIF carries EXIF in exactly the same structure. It sets `set_base_offset` to the payload's real file position so IsOffset tags land on the right bytes, the way the JPEG path does.

### Tests

`tests/heif_exif_test.rs`, 7 tests over synthetic containers built in the test: the item is found and the payload header skipped, `infe` version 2 and version 3 each parse, a payload with no `Exif\0\0` header is accepted, a file with no EXIF item reports absence rather than an error, `iloc` field widths are read from the box, and truncated boxes at several cut points do not panic.

No image fixture, since all of this is expressible in synthetic bytes and a real HEIF is 16 MB.

### Not in scope

- **Construction method 1**, where the payload lives in `idat`. The files I have use method 0. ExifTool supports method 1 and this reports it as unextracted rather than guessing.
- **XMP and PLIST items.** `HandleItemInfo` also maps `application/rdf+xml` and `uri ` items, and the same `extract_exif_item` shape would serve them.
- **Rendering conventions**, which are crate-wide rather than HEIF. The 220 mismatches are almost entirely `XResolution` printing as `72.0` against exiftool's `72`, `ComponentsConfiguration` as a byte array, and similar. The same diffs appear in the EXIF group of a JPEG on main.

Stacking note: this touches `src/formats/` only, and #31 touches `src/exif/` only, so the two are independent and can merge in either order. Together they take that `.HIF` from 17 tags to full EXIF plus a named FujiFilm film recipe.

### Checks

`cargo fmt --check` clean. `cargo test --release` unchanged from main apart from the new file: the failures in `cli_tag_filtering_integration_test.rs` all need the `test-images/` corpus, which is fetched by a Makefile target rather than committed.
